### PR TITLE
Fix division by 0 issue when all scores are zero

### DIFF
--- a/graph_ga/goal_directed_generation.py
+++ b/graph_ga/goal_directed_generation.py
@@ -37,8 +37,11 @@ def make_mating_pool(population_mol: List[Mol], population_scores, offspring_siz
     """
     # scores -> probs
     sum_scores = sum(population_scores)
-    population_probs = [p / sum_scores for p in population_scores]
-    mating_pool = np.random.choice(population_mol, p=population_probs, size=offspring_size, replace=True)
+    if sum_scores > 0.0:
+        population_probs = [p / sum_scores for p in population_scores]
+        mating_pool = np.random.choice(population_mol, p=population_probs, size=offspring_size, replace=True)
+    else:
+        mating_pool = np.random.choice(population_mol, size=offspring_size, replace=True)
     return mating_pool
 
 


### PR DESCRIPTION
In `graph_ga/goal_directed_generation.py` the mating pool is selected through weighted random sampling, with the probability of a molecule being selected given by its score divided by the sum of all scores (`sum_scores`).

https://github.com/BenevolentAI/guacamol_baselines/blob/44d24c53f3acf9266eb2fb06dbff909836549291/graph_ga/goal_directed_generation.py#L25-L42

If `sum_scores == 0.0` we get a division by 0. This actually occurs during the Valsartan SMARTS benchmark when using random starting molecules due to its binary nature.